### PR TITLE
Added Insolator recipes for Mystical Agriculture (1.18.2)

### DIFF
--- a/src/main/java/cofh/thermal/integration/ThermalIntegration.java
+++ b/src/main/java/cofh/thermal/integration/ThermalIntegration.java
@@ -32,6 +32,7 @@ public class ThermalIntegration {
         TIntConfig.addModConfig("redstone_arsenal", "Redstone Arsenal");
         TIntConfig.addModConfig("refinedstorage", "Refined Storage");
         TIntConfig.addModConfig("tconstruct", "Tinker's Construct");
+        TIntConfig.addModConfig("mysticalagriculture", "Mystical Agriculture");
 
         COMPAT_CONFIG_MANAGER.register(modEventBus)
                 .addCommonConfig(new TIntConfig());

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:air_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:air_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:air_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:air"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:air"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_air_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:aluminum_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:aluminum_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:aluminum_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:aluminum"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/aluminum"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:aluminum"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/aluminum"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/aluminum"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aluminum_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:aluminum"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:amethyst_bronze_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:amethyst_bronze_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:amethyst_bronze_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:amethyst_bronze"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:amethyst_bronze"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_bronze_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:amethyst_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:amethyst_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:amethyst_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:amethyst"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_amethyst_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:amethyst"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:apatite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:apatite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:apatite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:apatite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:apatite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_apatite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:aquamarine_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:aquamarine_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:aquamarine_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:aquamarine"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_aquamarine_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:aquamarine"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:basalt_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:basalt_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:basalt_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:basalt"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalt_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:basalt"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:basalz_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:basalz_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:basalz_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:basalz"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:basalz"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_basalz_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:blaze"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blaze_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:blaze_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:blaze_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:blaze_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:blaze"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:blazing_crystal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:blazing_crystal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:blazing_crystal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:blazing_crystal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:blazing_crystal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blazing_crystal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:blitz"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blitz_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:blitz_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:blitz_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:blitz_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:blitz"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:blizz_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:blizz_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:blizz_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:blizz"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:blizz"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_blizz_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:brass"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:brass"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/brass"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/brass"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_brass_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:brass_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:brass_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:brass_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:brass"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/brass"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:bronze"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_bronze_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:bronze_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:bronze_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:bronze_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:bronze"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:certus_quartz_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:certus_quartz_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:certus_quartz_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:certus_quartz"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_certus_quartz_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:certus_quartz"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:chicken"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:chicken_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:chicken_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:chicken_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:chicken"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chicken_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:chrome"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:chrome_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:chrome_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:chrome_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:chrome"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/chrome"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_chrome_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:chrome"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/chrome"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/chrome"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:coal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:coal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:coal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:coal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:coal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:cobalt_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:cobalt_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:cobalt_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:cobalt"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cobalt_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:cobalt"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:compressed_iron_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:compressed_iron_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:compressed_iron_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:compressed_iron"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:compressed_iron"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_compressed_iron_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:constantan"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:constantan_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:constantan_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:constantan_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:constantan"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_constantan_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:copper"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_copper_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:copper_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:copper_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:copper_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:copper"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:coral"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:coral_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:coral_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:coral_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:coral"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_coral_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:cow"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:cow_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:cow_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:cow_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:cow"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cow_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:creeper"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:creeper_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:creeper_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:creeper_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:creeper"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_creeper_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:cyanite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:cyanite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:cyanite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:cyanite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_cyanite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:cyanite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:deepslate"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_deepslate_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:deepslate_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:deepslate_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:deepslate_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:deepslate"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:diamond_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:diamond_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:diamond_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:diamond"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_diamond_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:diamond"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:dirt_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:dirt_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:dirt_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:dirt"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dirt_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:dirt"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:draconium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:draconium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:draconium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:draconium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:draconium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_draconium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:dye"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_dye_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:dye_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:dye_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:dye_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:dye"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:earth_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:earth_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:earth_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:earth"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_earth_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:earth"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:electrum_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:electrum_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:electrum_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:electrum"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_electrum_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:electrum"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:elementium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:elementium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:elementium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:elementium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:elementium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_elementium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:emerald"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:emerald_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:emerald_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:emerald_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:emerald"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_emerald_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:end_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:end_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:end_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:end"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:end"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_end_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:enderium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:enderium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:enderium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:enderium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:enderium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:enderman"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:enderman_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:enderman_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:enderman_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:enderman"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_enderman_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:energized_steel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:energized_steel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:energized_steel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:energized_steel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:energized_steel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_energized_steel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:experience_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:experience_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:experience_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:experience"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_experience_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:experience"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:fiery_ingot_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:fiery_ingot_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:fiery_ingot_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:fiery_ingot"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:fiery_ingot"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fiery_ingot_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:fire"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fire_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:fire_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:fire_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:fire_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:fire"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:fish_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:fish_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:fish_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:fish"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:fish"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fish_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:fluix"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluix_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:fluix_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:fluix_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:fluix_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:fluix"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:fluorite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:fluorite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:fluorite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:fluorite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_fluorite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:fluorite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:ghast"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:ghast_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:ghast_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:ghast_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:ghast"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ghast_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:glowstone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:glowstone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:glowstone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:glowstone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:glowstone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_glowstone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:gold"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:gold_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:gold_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:gold_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:gold"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_gold_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:graphite"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:graphite"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/graphite"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/graphite"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_graphite_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:graphite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:graphite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:graphite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:graphite"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/graphite"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:hepatizon_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:hepatizon_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:hepatizon_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:hepatizon"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hepatizon_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:hepatizon"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:honey_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:honey_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:honey_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:honey"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_honey_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:honey"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:hop_graphite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:hop_graphite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:hop_graphite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:hop_graphite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:hop_graphite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_hop_graphite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:ice_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:ice_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:ice_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:ice"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ice_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:ice"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:inferium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:inferium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:inferium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:inferium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:inferium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_inferium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:invar_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:invar_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:invar_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:invar"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:invar"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_invar_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:iridium"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:iridium"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/iridium"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/iridium"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iridium_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:iridium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:iridium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:iridium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:iridium"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/iridium"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:iron_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:iron_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:iron_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:iron"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:iron"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_iron_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:ironwood"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ironwood_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:ironwood_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:ironwood_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:ironwood_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:ironwood"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:knightmetal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:knightmetal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:knightmetal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:knightmetal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:knightmetal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_knightmetal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:lapis_lazuli"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:lapis_lazuli_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:lapis_lazuli_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:lapis_lazuli_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:lapis_lazuli"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lapis_lazuli_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:lead"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lead_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:lead_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:lead_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:lead_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:lead"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:limestone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_limestone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:limestone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:limestone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:limestone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:limestone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:lumium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:lumium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:lumium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:lumium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_lumium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:lumium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:manasteel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:manasteel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:manasteel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:manasteel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:manasteel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manasteel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:manyullyn_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:manyullyn_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:manyullyn_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:manyullyn"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_manyullyn_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:manyullyn"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:marble_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:marble_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:marble_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:marble"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_marble_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:marble"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:menril_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:menril_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:menril_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:menril"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:menril"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_menril_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:mithril_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:mithril_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:mithril_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:mithril"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/mithril"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:mithril"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mithril_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:mithril"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/mithril"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/mithril"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:mystical_flower"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:mystical_flower_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:mystical_flower_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:mystical_flower_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:mystical_flower"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_mystical_flower_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:nature_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:nature_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:nature_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:nature"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nature_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:nature"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:nether_quartz_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:nether_quartz_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:nether_quartz_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:nether_quartz"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_quartz_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:nether_quartz"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:nether_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:nether_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:nether_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:nether"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:nether"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nether_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:netherite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_netherite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:netherite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:netherite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:netherite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:netherite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:nickel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:nickel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:nickel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:nickel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:nickel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_nickel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:niotic_crystal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:niotic_crystal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:niotic_crystal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:niotic_crystal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:niotic_crystal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_niotic_crystal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:obsidian"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_obsidian_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:obsidian_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:obsidian_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:obsidian_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:obsidian"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:osmium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:osmium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:osmium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:osmium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:osmium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_osmium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:pig_iron"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_iron_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:pig_iron_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:pig_iron_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:pig_iron_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:pig_iron"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:pig_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:pig_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:pig_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:pig"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_pig_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:pig"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:platinum_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:platinum_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:platinum_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:platinum"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/platinum"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:platinum"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/platinum"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/platinum"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_platinum_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:platinum"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:prismarine"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_prismarine_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:prismarine_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:prismarine_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:prismarine_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:prismarine"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:quartz_enriched_iron"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_quartz_enriched_iron_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:quartz_enriched_iron_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:quartz_enriched_iron_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:quartz_enriched_iron_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:quartz_enriched_iron"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:queens_slime_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:queens_slime_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:queens_slime_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:queens_slime"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:queens_slime"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_queens_slime_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:rabbit_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:rabbit_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:rabbit_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:rabbit"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rabbit_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:rabbit"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:redstone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:redstone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:redstone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:redstone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:redstone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_redstone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:refined_glowstone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_glowstone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:refined_glowstone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:refined_glowstone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:refined_glowstone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:refined_glowstone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:refined_obsidian"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:refined_obsidian_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:refined_obsidian_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:refined_obsidian_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:refined_obsidian"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_refined_obsidian_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:rock_crystal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:rock_crystal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:rock_crystal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:rock_crystal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rock_crystal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:rock_crystal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:rose_gold_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:rose_gold_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:rose_gold_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:rose_gold"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rose_gold_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:rose_gold"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:rubber_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:rubber_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:rubber_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:rubber"
+        },
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:rubber"
+            }
+        },
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:rubber"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:rubber"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:rubber"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_rubber_seeds.json
@@ -29,7 +29,6 @@
                 "type": "forge:tag_empty",
                 "tag": "forge:rubber"
             }
-        },
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:ruby_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:ruby_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:ruby_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:ruby"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_ruby_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:ruby"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:saltpeter_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:saltpeter_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:saltpeter_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:saltpeter"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_saltpeter_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:saltpeter"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:sapphire"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sapphire_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:sapphire_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:sapphire_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:sapphire_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:sapphire"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:sheep_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:sheep_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:sheep_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:sheep"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sheep_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:sheep"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:signalum_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:signalum_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:signalum_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:signalum"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_signalum_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:signalum"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:silicon"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:silicon"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:silicon"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
@@ -29,7 +29,6 @@
                 "type": "forge:tag_empty",
                 "tag": "forge:silicon"
             }
-        },
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silicon_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:silicon_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:silicon_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:silicon_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:silicon"
+        },
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:silicon"
+            }
+        },
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:silver"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:silver_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:silver_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:silver_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:silver"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_silver_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:skeleton_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:skeleton_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:skeleton_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:skeleton"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:skeleton"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_skeleton_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:sky_stone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sky_stone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:sky_stone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:sky_stone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:sky_stone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:sky_stone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:slime_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:slime_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:slime_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:slime"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slime_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:slime"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:slimesteel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:slimesteel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:slimesteel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:slimesteel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:slimesteel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_slimesteel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:spider"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spider_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:spider_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:spider_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:spider_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:spider"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:spirited_crystal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:spirited_crystal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:spirited_crystal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:spirited_crystal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:spirited_crystal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_spirited_crystal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:squid_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:squid_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:squid_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:squid"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_squid_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:squid"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:starmetal_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:starmetal_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:starmetal_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:starmetal"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:starmetal"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_starmetal_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:steel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:steel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:steel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:steel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:steel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:steeleaf_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:steeleaf_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:steeleaf_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:steeleaf"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:steeleaf"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_steeleaf_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:stone"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_stone_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:stone_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:stone_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:stone_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:stone"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:sulfur_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:sulfur_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:sulfur_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:sulfur"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:sulfur"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_sulfur_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:terrasteel"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_terrasteel_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:terrasteel_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:terrasteel_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:terrasteel_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:terrasteel"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:tin_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:tin_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:tin_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:tin"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:tin"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tin_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:tinkers_bronze_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:tinkers_bronze_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:tinkers_bronze_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:tinkers_bronze"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tinkers_bronze_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:tinkers_bronze"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:titanium"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/titanium"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/titanium"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:titanium"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_titanium_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:titanium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:titanium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:titanium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:titanium"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/titanium"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:tungsten"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/tungsten"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/tungsten"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:tungsten_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:tungsten_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:tungsten_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:tungsten"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/tungsten"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_tungsten_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:tungsten"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:turtle_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:turtle_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:turtle_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:turtle"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_turtle_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:turtle"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:uraninite_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:uraninite_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:uraninite_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:uraninite"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:uraninite"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uraninite_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:uranium"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:uranium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:uranium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:uranium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:uranium"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/uranium"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_uranium_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:uranium"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/uranium"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/uranium"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:water_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:water_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:water_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:water"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:water"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_water_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:wither_skeleton"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:wither_skeleton_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:wither_skeleton_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:wither_skeleton_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:wither_skeleton"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wither_skeleton_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:wood"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_wood_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:wood_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:wood_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:wood_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:wood"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:yellorium"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:yellorium_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:yellorium_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:yellorium_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:yellorium"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_yellorium_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
@@ -23,7 +23,6 @@
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:zinc"
         },
-        null,
         {
             "type": "forge:not",
             "value": {

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
@@ -1,0 +1,35 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:zinc_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:zinc_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:zinc_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:zinc"
+        },
+        null,
+        {
+            "type": "forge:not",
+            "value": {
+                "type": "forge:tag_empty",
+                "tag": "forge:ingots/zinc"
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zinc_seeds.json
@@ -16,19 +16,16 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:zinc"
         },
         {
-            "type": "forge:not",
-            "value": {
-                "type": "forge:tag_empty",
-                "tag": "forge:ingots/zinc"
-            }
+            "type": "cofh_core:tag_exists",
+            "tag": "forge:ingots/zinc"
         }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
@@ -1,0 +1,29 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "mysticalagriculture:zombie_seeds"
+    },
+    "result": [
+        {
+            "item": "mysticalagriculture:zombie_essence",
+            "count": 1
+        },
+        {
+            "item": "mysticalagriculture:zombie_seeds",
+            "count": 1
+        }
+    ],
+    "energy": 100000,
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "mysticalagriculture"
+        },
+        {
+            "type": "mysticalagriculture:crop_has_material",
+            "crop": "mysticalagriculture:zombie"
+        },
+        null,
+        null
+    ]
+}

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
@@ -22,8 +22,6 @@
         {
             "type": "mysticalagriculture:crop_has_material",
             "crop": "mysticalagriculture:zombie"
-        },
-        null,
-        null
+        }
     ]
 }

--- a/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
+++ b/src/main/resources/data/thermal/recipes/compat/mysticalagriculture/insolator_mysticalag_zombie_seeds.json
@@ -16,8 +16,8 @@
     "energy": 100000,
     "conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "mysticalagriculture"
+            "type": "thermal:flag",
+            "flag": "mod_mysticalagriculture"
         },
         {
             "type": "mysticalagriculture:crop_has_material",


### PR DESCRIPTION
Just added Insolator recipes for all Mystical Agriculture seeds as how they work in 1.16.5 (1 seed produces 1 essence + 1 seed, 100,000 RF per cycle), generated by this [neat little script](https://gist.github.com/shanoaice/33627e87a05169a168fedda826f2dfec).
I added empty tag condition to some recipes that can potentially be depending on those ingredients (such as brass, rubber, etc.). Hopefully I didn't mess things up (it works fine on my 1.18.2 simulation, but I am not sure whether I have left anything behind).